### PR TITLE
Loop through multiple directories and test for drupal installs

### DIFF
--- a/security-updates.sh
+++ b/security-updates.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Place this script in cron and run once per hour.
 
+# run `which drush` to find this path
+drush='/usr/bin/drush'
 WEBROOT="/var/www"
 EMAIL="me@example.com"
 BACKUP_DIR = "~/backups/manual"
@@ -18,8 +20,8 @@ do
 	cd $SITE_DIR && cd public_html
 	echo $(pwd) 
 	# first check to see if site directory has a drupal site
-	STATUS=$($drush status | wc -l)
-	if [[ $status -gt 7 ]]
+	SITE_STATUS=$($drush status | wc -l)
+	if [[ $SITE_STATUS -gt 7 ]]
 	then 
 		echo "Drupal site found"
 		# Make sure status is up to date
@@ -30,12 +32,13 @@ do
 		then
 			drush vset maintance_mode 1
 			# Take a backup and if it succeeds, run the update
-			drush sql-dump | gzip > ~/${BACKUP_DIR}/${i}-pre-sec-update.sql.gz && drush up --security-only -y
+			drush sql-dump | gzip > ${BACKUP_DIR}/${i}-pre-sec-update.sql.gz && drush up --security-only -y
 			drush vset maintance_mode 0
 		  # Notify stakeholders
 			echo "A critical security update has been applied to $i. You should test production now." | mail -s "Your website needs testing" "$EMAIL";
 		else
 			echo "No available security updates"
+		fi
 	else
 		echo "No Drupal Site Found"
 	fi 

--- a/security-updates.sh
+++ b/security-updates.sh
@@ -32,10 +32,10 @@ do
 		then
 			drush vset maintance_mode 1
 			# Take a backup and if it succeeds, run the update
-			drush sql-dump | gzip > ${BACKUP_DIR}/${i}-pre-sec-update.sql.gz && drush up --security-only -y
+			drush sql-dump | gzip > ${BACKUP_DIR}/${i}-pre-sec-update.sql.gz && drush up --security-only -y && mail -s "Your website needs testing" "$EMAIL"
 			drush vset maintance_mode 0
 		  # Notify stakeholders
-			echo "A critical security update has been applied to $i. You should test production now." | mail -s "Your website needs testing" "$EMAIL";
+			echo "A critical security update has been applied to $i. You should test production now."
 		else
 			echo "No available security updates"
 		fi

--- a/security-updates.sh
+++ b/security-updates.sh
@@ -1,25 +1,40 @@
 #!/bin/bash
 # Place this script in cron and run once per hour.
 
-WEBROOT="/var/www/html"
+WEBROOT="/var/www"
 EMAIL="me@example.com"
-SITE_NAME="example.com"
 
+echo "Scanning sites directory for drupal installations"
 cd $WEBROOT
 
-# Make sure status is up to date
- drush pm-refresh
+for i in $(ls)
+do 
+	SITE_DIR=$(readlink -f $i)
+	# if your site files are in directories immediately
+	# beneath your site_dir, i.e. /var/www/site.com,
+	# then you don't need to `cd public_html'
+	# just use `cd $a` below
+	cd $a && cd public_html
+	echo $(pwd) 
+	# Make sure status is up to date
+	 drush pm-refresh
 
-# Check for Security Updates
-OUTPUT="$(drush pm-updatestatus --security-only)"
-if [[ $OUTPUT == *"UPDATE"* ]]
-then
-  drush vset maintance_mode 1
+	# Check for Security Updates
+	OUTPUT="$(drush pm-updatestatus --security-only)"
+	if [[ $OUTPUT == *"UPDATE"* ]]
+	then
+	  echo "Drupal site found"
+	  drush vset maintance_mode 1
 
-  # Take a backup and if it succeeds, run the update
-  drush sql-dump | gzip > ~/backup/prod.sql.gz && drush up --security-only -y
-  drush vset maintance_mode 0
+	  # Take a backup and if it succeeds, run the update
+	  drush sql-dump | gzip > ~/backup/prod.sql.gz && drush up --security-only -y
+	  drush vset maintance_mode 0
 
-  # Notify stakeholders
-  echo "A critical security update has been applied to $SITE_NAME. You should test production now." | mail -s "Your website needs testing" "$EMAIL";
-fi
+	  # Notify stakeholders
+	  echo "A critical security update has been applied to $SITE_NAME. You should test production now." | mail -s "Your website needs testing" "$EMAIL";
+	  else
+		echo "No Drupal site found in this directory"
+	  fi 
+	  cd $WEBROOT
+done
+echo "Done with Drupal Security Updates"

--- a/security-updates.sh
+++ b/security-updates.sh
@@ -14,7 +14,7 @@ do
 	# beneath your site_dir, i.e. /var/www/site.com,
 	# then you don't need to `cd public_html'
 	# just use `cd $a` below
-	cd $a && cd public_html
+	cd $SITE_DIR && cd public_html
 	echo $(pwd) 
 	# Make sure status is up to date
 	 drush pm-refresh

--- a/security-updates.sh
+++ b/security-updates.sh
@@ -3,6 +3,7 @@
 
 WEBROOT="/var/www"
 EMAIL="me@example.com"
+BACKUP_DIR = "~/backups/manual"
 
 echo "Scanning sites directory for drupal installations"
 cd $WEBROOT
@@ -29,10 +30,10 @@ do
 		then
 			drush vset maintance_mode 1
 			# Take a backup and if it succeeds, run the update
-			drush sql-dump | gzip > ~/backup/prod.sql.gz && drush up --security-only -y
+			drush sql-dump | gzip > ~/${BACKUP_DIR}/${i}-pre-sec-update.sql.gz && drush up --security-only -y
 			drush vset maintance_mode 0
 		  # Notify stakeholders
-			echo "A critical security update has been applied to $SITE_DIR. You should test production now." | mail -s "Your website needs testing" "$EMAIL";
+			echo "A critical security update has been applied to $i. You should test production now." | mail -s "Your website needs testing" "$EMAIL";
 		else
 			echo "No available security updates"
 	else

--- a/security-updates.sh
+++ b/security-updates.sh
@@ -31,7 +31,7 @@ do
 	  drush vset maintance_mode 0
 
 	  # Notify stakeholders
-	  echo "A critical security update has been applied to $SITE_NAME. You should test production now." | mail -s "Your website needs testing" "$EMAIL";
+	  echo "A critical security update has been applied to $SITE_DIR. You should test production now." | mail -s "Your website needs testing" "$EMAIL";
 	  else
 		echo "No Drupal site found in this directory"
 	  fi 


### PR DESCRIPTION
I put much of your code in a loop through webroot that runs two tests, first two see if there's a drupal site there, and then to check for security updates. I modified the db backup path and naming to handling multiple sites; however, it didn't work the first time I tried it. The other major change was making the mail command dependent on the drush update command.
